### PR TITLE
Pablo/dev 95 headers on sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv/
+.venv
 src/*.egg-info/
 __pycache__/
 .pytest_cache/
@@ -9,3 +10,4 @@ utils.bak.py
 site**
 .pypirc
 dist/
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 venv/
-.venv
 src/*.egg-info/
 __pycache__/
 .pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ utils.bak.py
 site**
 .pypirc
 dist/
+build

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ utils.bak.py
 site**
 .pypirc
 dist/
-.idea

--- a/src/glassflow/config.py
+++ b/src/glassflow/config.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import requests
-from typing import Tuple
+from importlib.metadata import version
 
 
 @dataclass
@@ -16,5 +16,5 @@ class GlassFlowConfig:
     """
     client: requests.Session
     server_url: str = 'https://api.glassflow.xyz/v1'
-    sdk_version: str = '0.0.2'
+    sdk_version: str = version('glassflow')
     user_agent: str = 'glassflow-python-sdk'

--- a/src/glassflow/config.py
+++ b/src/glassflow/config.py
@@ -17,4 +17,5 @@ class GlassFlowConfig:
     client: requests.Session
     server_url: str = 'https://api.glassflow.xyz/v1'
     sdk_version: str = version('glassflow')
-    user_agent: str = 'glassflow-python-sdk'
+    user_agent: str = 'glassflow-python-sdk/{}'.format(sdk_version)
+    glassflow_client: str = 'python-sdk/{}'.format(sdk_version)

--- a/src/glassflow/pipelines.py
+++ b/src/glassflow/pipelines.py
@@ -241,7 +241,7 @@ class PipelineClient():
         headers = utils.get_req_specific_headers(request)
         headers['Accept'] = 'application/json'
         headers['Gf-Client'] = (
-            f'{self.glassflow_client.glassflow_config.user_agent} / '
+            f'{self.glassflow_client.glassflow_config.user_agent}/'
             f'{self.glassflow_client.glassflow_config.sdk_version}')
         headers['user-agent'] = headers['Gf-Client']
         headers['Gf-Python-Version'] = (f'{sys.version_info.major}.'

--- a/src/glassflow/pipelines.py
+++ b/src/glassflow/pipelines.py
@@ -240,13 +240,13 @@ class PipelineClient():
 
         headers = utils.get_req_specific_headers(request)
         headers['Accept'] = 'application/json'
-        headers['user-agent'] = (
-            self.glassflow_client.glassflow_config.user_agent)
-        headers['X-PYTHON-VERSION'] = (f'{sys.version_info.major}.'
-                                       f'{sys.version_info.minor}.'
-                                       f'{sys.version_info.micro}')
-        headers['X-PYTHON-SDK-VERSION'] = (
-            self.glassflow_client.glassflow_config.sdk_version)
+        headers['Gf-Client'] = (
+            f'{self.glassflow_client.glassflow_config.user_agent} / '
+            f'{self.glassflow_client.glassflow_config.sdk_version}')
+        headers['user-agent'] = headers['Gf-Client']
+        headers['Gf-Python-Version'] = (f'{sys.version_info.major}.'
+                                        f'{sys.version_info.minor}.'
+                                        f'{sys.version_info.micro}')
 
         if (req_content_type and req_content_type not in
                 ('multipart/form-data', 'multipart/mixed')):

--- a/src/glassflow/pipelines.py
+++ b/src/glassflow/pipelines.py
@@ -238,7 +238,7 @@ class PipelineClient():
             req_content_type: Optional[str] = None
     ) -> dict:
 
-        headers = utils.get_headers(request)
+        headers = utils.get_req_specific_headers(request)
         headers['Accept'] = 'application/json'
         headers['user-agent'] = (
             self.glassflow_client.glassflow_config.user_agent)

--- a/src/glassflow/pipelines.py
+++ b/src/glassflow/pipelines.py
@@ -1,3 +1,5 @@
+import dataclasses
+import sys
 from .models import operations, errors
 from typing import Dict, Optional
 import glassflow.utils as utils
@@ -55,20 +57,14 @@ class PipelineClient():
         url = utils.generate_url(
             operations.PublishEventRequest, base_url,
             '/pipelines/{pipeline_id}/topics/input/events', request)
-        headers = utils.get_headers(request)
 
         req_content_type, data, form = utils.serialize_request_body(
             request, operations.PublishEventRequest, "request_body", False,
             True, 'json')
-        if req_content_type not in ('multipart/form-data', 'multipart/mixed'):
-            headers['content-type'] = req_content_type
 
+        headers = self._get_headers(request, req_content_type)
         query_params = utils.get_query_params(operations.PublishEventRequest,
                                               request)
-
-        headers['Accept'] = 'application/json'
-        headers[
-            'user-agent'] = self.glassflow_client.glassflow_config.user_agent
 
         client = self.glassflow_client.glassflow_config.client
 
@@ -124,12 +120,10 @@ class PipelineClient():
         url = utils.generate_url(
             operations.ConsumeEventRequest, base_url,
             '/pipelines/{pipeline_id}/topics/output/events/consume', request)
-        headers = utils.get_headers(request)
+        headers = self._get_headers(request)
         query_params = utils.get_query_params(operations.ConsumeEventRequest,
                                               request)
-        headers['Accept'] = 'application/json'
-        headers[
-            'user-agent'] = self.glassflow_client.glassflow_config.user_agent
+
         client = self.glassflow_client.glassflow_config.client
         http_res = client.request('POST',
                                   url,
@@ -193,12 +187,10 @@ class PipelineClient():
         url = utils.generate_url(
             operations.ConsumeFailedRequest, base_url,
             '/pipelines/{pipeline_id}/topics/failed/events/consume', request)
-        headers = utils.get_headers(request)
+        headers = self._get_headers(request)
         query_params = utils.get_query_params(operations.ConsumeFailedRequest,
                                               request)
-        headers['Accept'] = 'application/json'
-        headers[
-            'user-agent'] = self.glassflow_client.glassflow_config.user_agent
+
         client = self.glassflow_client.glassflow_config.client
         http_res = client.request('POST',
                                   url,
@@ -240,3 +232,24 @@ class PipelineClient():
                                      http_res)
 
         return res
+
+    def _get_headers(
+            self, request: dataclasses.dataclass,
+            req_content_type: Optional[str] = None
+    ) -> dict:
+
+        headers = utils.get_headers(request)
+        headers['Accept'] = 'application/json'
+        headers['user-agent'] = (
+            self.glassflow_client.glassflow_config.user_agent)
+        headers['X-PYTHON-VERSION'] = (f'{sys.version_info.major}.'
+                                       f'{sys.version_info.minor}.'
+                                       f'{sys.version_info.micro}')
+        headers['X-PYTHON-SDK-VERSION'] = (
+            self.glassflow_client.glassflow_config.sdk_version)
+
+        if (req_content_type and req_content_type not in
+                ('multipart/form-data', 'multipart/mixed')):
+            headers['content-type'] = req_content_type
+
+        return headers

--- a/src/glassflow/pipelines.py
+++ b/src/glassflow/pipelines.py
@@ -240,10 +240,8 @@ class PipelineClient():
 
         headers = utils.get_req_specific_headers(request)
         headers['Accept'] = 'application/json'
-        headers['Gf-Client'] = (
-            f'{self.glassflow_client.glassflow_config.user_agent}/'
-            f'{self.glassflow_client.glassflow_config.sdk_version}')
-        headers['user-agent'] = headers['Gf-Client']
+        headers['Gf-Client'] = self.glassflow_client.glassflow_config.glassflow_client
+        headers['User-Agent'] = self.glassflow_client.glassflow_config.user_agent
         headers['Gf-Python-Version'] = (f'{sys.version_info.major}.'
                                         f'{sys.version_info.minor}.'
                                         f'{sys.version_info.micro}')

--- a/src/glassflow/utils/utils.py
+++ b/src/glassflow/utils/utils.py
@@ -161,7 +161,7 @@ def get_query_params(
     return params
 
 
-def get_headers(headers_params: dataclass) -> Dict[str, str]:
+def get_req_specific_headers(headers_params: dataclass) -> Dict[str, str]:
     if headers_params is None:
         return {}
 


### PR DESCRIPTION
This PR changes:

- Gets sdk version from `importlib` so we don't have to manually write it in two places at the same time
- Add headers:
  - `Gf-Python-Version = <major>.<minor>.<micro>`
  - `Gf-Client = python-sdk/<sdk version>`
- And updates `User-Agent` header to be `glassflow-python-sdk/<sdk version>`
- Move headers logic to a separated private method in the `PipelineClient`
