### PR TITLE
Pablo/dev 157 add personal management token parameter to gf client

### DIFF
--- a/src/glassflow/__init__.py
+++ b/src/glassflow/__init__.py
@@ -1,3 +1,4 @@
 from .client import GlassFlowClient as GlassFlowClient
 from .config import GlassFlowConfig as GlassFlowConfig
+from .models import errors as errors
 from .pipelines import PipelineDataSource, PipelineDataSink

--- a/src/glassflow/__init__.py
+++ b/src/glassflow/__init__.py
@@ -1,2 +1,3 @@
 from .client import GlassFlowClient as GlassFlowClient
 from .config import GlassFlowConfig as GlassFlowConfig
+from .pipelines import PipelineDataSource, PipelineDataSink

--- a/src/glassflow/api_client.py
+++ b/src/glassflow/api_client.py
@@ -1,0 +1,35 @@
+import sys
+from dataclasses import dataclass
+from typing import Optional
+
+import requests as requests_http
+
+from .config import GlassFlowConfig
+from .utils import get_req_specific_headers
+
+
+class APIClient:
+    def __init__(self):
+        self.client = requests_http.Session()
+        self.glassflow_config = GlassFlowConfig()
+
+    def _get_headers(
+            self, request: dataclass, req_content_type: Optional[str] = None
+    ) -> dict:
+        headers = get_req_specific_headers(request)
+        headers["Accept"] = "application/json"
+        headers["Gf-Client"] = self.glassflow_config.glassflow_client
+        headers["User-Agent"] = self.glassflow_config.user_agent
+        headers["Gf-Python-Version"] = (
+            f"{sys.version_info.major}."
+            f"{sys.version_info.minor}."
+            f"{sys.version_info.micro}"
+        )
+
+        if req_content_type and req_content_type not in (
+                "multipart/form-data",
+                "multipart/mixed",
+        ):
+            headers["content-type"] = req_content_type
+
+        return headers

--- a/src/glassflow/client.py
+++ b/src/glassflow/client.py
@@ -20,13 +20,15 @@ class GlassFlowClient(APIClient):
     """
     glassflow_config: GlassFlowConfig
 
-    def __init__(self, organization_id: str = None) -> None:
+    def __init__(self, personal_access_token: str = None, organization_id: str = None) -> None:
         """Create a new GlassFlowClient object
 
         Args:
+            personal_access_token: GlassFlow Personal Access Token
             organization_id: Organization ID of the user. If not provided, the default organization will be used
         """
         super().__init__()
+        self.personal_access_token = personal_access_token
         self.organization_id = organization_id
 
     def pipeline_client(

--- a/src/glassflow/client.py
+++ b/src/glassflow/client.py
@@ -1,6 +1,7 @@
 """GlassFlow Python Client to interact with GlassFlow API"""
 
 import os
+import warnings
 from typing import Optional
 
 import requests as requests_http
@@ -51,6 +52,10 @@ class GlassFlowClient:
             pipeline_id = os.getenv("PIPELINE_ID")
         if not pipeline_access_token:
             pipeline_access_token = os.getenv("PIPELINE_ACCESS_TOKEN")
+        if space_id is not None:
+            warnings.warn("Space id not needed to publish or consume events",
+                          DeprecationWarning)
+
         # no pipeline_id provided explicitly or in environment variables
         if not pipeline_id:
             raise ValueError(

--- a/src/glassflow/client.py
+++ b/src/glassflow/client.py
@@ -4,17 +4,16 @@ import os
 import warnings
 from typing import Optional
 
-import requests as requests_http
-
 from .config import GlassFlowConfig
 from .pipelines import PipelineClient
+from .api_client import APIClient
 
 
-class GlassFlowClient:
+class GlassFlowClient(APIClient):
     """GlassFlow Client to interact with GlassFlow API and manage pipelines and other resources
 
     Attributes:
-        rclient: requests.Session object to make HTTP requests to GlassFlow API
+        client: requests.Session object to make HTTP requests to GlassFlow API
         glassflow_config: GlassFlowConfig object to store configuration
         organization_id: Organization ID of the user. If not provided, the default organization will be used
 
@@ -30,6 +29,7 @@ class GlassFlowClient:
         """
         rclient = requests_http.Session()
         self.glassflow_config = GlassFlowConfig(rclient)
+        super().__init__()
         self.organization_id = organization_id
 
     def pipeline_client(

--- a/src/glassflow/client.py
+++ b/src/glassflow/client.py
@@ -27,8 +27,6 @@ class GlassFlowClient(APIClient):
         Args:
             organization_id: Organization ID of the user. If not provided, the default organization will be used
         """
-        rclient = requests_http.Session()
-        self.glassflow_config = GlassFlowConfig(rclient)
         super().__init__()
         self.organization_id = organization_id
 

--- a/src/glassflow/client.py
+++ b/src/glassflow/client.py
@@ -18,7 +18,6 @@ class GlassFlowClient(APIClient):
         organization_id: Organization ID of the user. If not provided, the default organization will be used
 
     """
-
     glassflow_config: GlassFlowConfig
 
     def __init__(self, organization_id: str = None) -> None:
@@ -45,6 +44,9 @@ class GlassFlowClient(APIClient):
         Returns:
             PipelineClient: Client object to publish and consume events from the given pipeline.
         """
+        warnings.warn("Use PipelineDataSource or PipelineDataSink instead",
+                      DeprecationWarning)
+
         # if no pipeline_id or pipeline_access_token is provided, try to read from environment variables
         if not pipeline_id:
             pipeline_id = os.getenv("PIPELINE_ID")

--- a/src/glassflow/config.py
+++ b/src/glassflow/config.py
@@ -9,14 +9,12 @@ class GlassFlowConfig:
     """Configuration object for GlassFlowClient
 
     Attributes:
-        client: requests.Session object to interact with the GlassFlow API
         server_url: The base URL of the GlassFlow API
         sdk_version: The version of the GlassFlow Python SDK
         user_agent: The user agent to be used in the requests
 
     """
 
-    client: requests.Session
     server_url: str = "https://api.glassflow.dev/v1"
     sdk_version: str = version("glassflow")
     user_agent: str = "glassflow-python-sdk/{}".format(sdk_version)

--- a/src/glassflow/models/errors/__init__.py
+++ b/src/glassflow/models/errors/__init__.py
@@ -1,4 +1,6 @@
-from .clienterror import ClientError
+from .clienterror import (ClientError, PipelineNotFoundError,
+                          PipelineAccessTokenInvalidError)
 from .error import Error
 
-__all__ = ["Error", "ClientError"]
+__all__ = ["Error", "ClientError", "PipelineNotFoundError",
+           "PipelineAccessTokenInvalidError"]

--- a/src/glassflow/models/errors/clienterror.py
+++ b/src/glassflow/models/errors/clienterror.py
@@ -49,3 +49,23 @@ class ClientError(Exception):
             body = f"\n{self.body}"
 
         return f"{self.detail}: Status {self.status_code}{body}"
+
+
+class PipelineNotFoundError(ClientError):
+    def __init__(self, pipeline_id: str, raw_response: requests_http.Response):
+        super().__init__(
+            detail=f"Pipeline ID {pipeline_id} does not exist",
+            status_code=404,
+            body=raw_response.text,
+            raw_response=raw_response
+        )
+
+
+class PipelineAccessTokenInvalidError(ClientError):
+    def __init__(self, raw_response: requests_http.Response):
+        super().__init__(
+            detail=f"The Pipeline Access Token used is invalid",
+            status_code=401,
+            body=raw_response.text,
+            raw_response=raw_response
+        )

--- a/src/glassflow/models/operations/consumefailed.py
+++ b/src/glassflow/models/operations/consumefailed.py
@@ -70,7 +70,7 @@ class ConsumeFailedResponseBody:
 
 @dataclasses.dataclass
 class ConsumeFailedResponse:
-    """Response to consume an failed event from a pipeline
+    """Response to consume a failed event from a pipeline
 
     Attributes:
         content_type: HTTP response content type for this operation

--- a/src/glassflow/pipelines.py
+++ b/src/glassflow/pipelines.py
@@ -5,6 +5,7 @@ import time
 from typing import Optional
 
 import glassflow.utils as utils
+from glassflow.api_client import APIClient
 
 from .models import errors, operations
 
@@ -61,9 +62,7 @@ class PipelineClient:
 
         headers = self._get_headers(request)
 
-        client = self.glassflow_client.glassflow_config.client
-
-        http_res = client.request("GET", url, headers=headers)
+        http_res = self.glassflow_client.client.request("GET", url, headers=headers)
         content_type = http_res.headers.get("Content-Type")
 
         if http_res.status_code == 200:
@@ -138,9 +137,7 @@ class PipelineClient:
         headers = self._get_headers(request, req_content_type)
         query_params = utils.get_query_params(operations.PublishEventRequest, request)
 
-        client = self.glassflow_client.glassflow_config.client
-
-        http_res = client.request(
+        http_res = self.glassflow_client.client.request(
             "POST", url, params=query_params, data=data, files=form, headers=headers
         )
         content_type = http_res.headers.get("Content-Type")
@@ -199,11 +196,11 @@ class PipelineClient:
         headers = self._get_headers(request)
         query_params = utils.get_query_params(operations.ConsumeEventRequest, request)
 
-        client = self.glassflow_client.glassflow_config.client
         # make the request
         self._respect_retry_delay()
 
-        http_res = client.request("POST", url, params=query_params, headers=headers)
+        http_res = self.glassflow_client.client.request(
+            "POST", url, params=query_params, headers=headers)
         content_type = http_res.headers.get("Content-Type")
 
         res = operations.ConsumeEventResponse(
@@ -283,9 +280,9 @@ class PipelineClient:
         headers = self._get_headers(request)
         query_params = utils.get_query_params(operations.ConsumeFailedRequest, request)
 
-        client = self.glassflow_client.glassflow_config.client
         self._respect_retry_delay()
-        http_res = client.request("POST", url, params=query_params, headers=headers)
+        http_res = self.glassflow_client.client.request(
+            "POST", url, params=query_params, headers=headers)
         content_type = http_res.headers.get("Content-Type")
 
         res = operations.ConsumeFailedResponse(

--- a/src/glassflow/pipelines.py
+++ b/src/glassflow/pipelines.py
@@ -2,6 +2,7 @@ import dataclasses
 import random
 import sys
 import time
+import warnings
 from typing import Optional
 
 import glassflow.utils as utils
@@ -19,6 +20,8 @@ class PipelineClient:
         organization_id: Organization ID of the user. If not provided, the default organization will be used
         pipeline_access_token: The access token to access the pipeline
     """
+    warnings.warn("Use PipelineDataSource or PipelineDataSink instead",
+                  DeprecationWarning)
 
     def __init__(
         self, glassflow_client, pipeline_id: str, pipeline_access_token: str

--- a/src/glassflow/pipelines.py
+++ b/src/glassflow/pipelines.py
@@ -363,3 +363,303 @@ class PipelineClient:
         if self._consume_retry_delay_current > self._consume_retry_delay_minimum:
             # sleep before making the request
             time.sleep(self._consume_retry_delay_current)
+
+
+class PipelineDataClient(APIClient):
+    """Base Client object to publish and consume events from the given pipeline.
+
+    Attributes:
+        glassflow_config: GlassFlowConfig object to interact with GlassFlow API
+        pipeline_id: The pipeline id to interact with
+        pipeline_access_token: The access token to access the pipeline
+    """
+    def __init__(self, pipeline_id: str, pipeline_access_token: str):
+        super().__init__()
+        self.pipeline_id = pipeline_id
+        self.pipeline_access_token = pipeline_access_token
+
+    def validate_credentials(self) -> None:
+        """
+        Check if the pipeline credentials are valid and raise an error if not
+        """
+        request = operations.StatusAccessTokenRequest(
+            pipeline_id=self.pipeline_id,
+            x_pipeline_access_token=self.pipeline_access_token,
+        )
+
+        url = utils.generate_url(
+            operations.PublishEventRequest,
+            self.glassflow_config.server_url,
+            "/pipelines/{pipeline_id}/status/access_token",
+            request,
+        )
+
+        headers = self._get_headers(request)
+
+        http_res = self.client.request("GET", url, headers=headers)
+        content_type = http_res.headers.get("Content-Type")
+
+        if http_res.status_code == 200:
+            return
+        if http_res.status_code == 401:
+            raise errors.PipelineAccessTokenInvalidError(http_res)
+        elif http_res.status_code == 404:
+            raise errors.PipelineNotFoundError(self.pipeline_id, http_res)
+        elif http_res.status_code in [400, 500]:
+            if utils.match_content_type(content_type, "application/json"):
+                out = utils.unmarshal_json(http_res.text, errors.Error)
+                out.raw_response = http_res
+                raise out
+            else:
+                raise errors.ClientError(
+                    f"unknown content-type received: {content_type}",
+                    http_res.status_code,
+                    http_res.text,
+                    http_res,
+                )
+        elif 400 < http_res.status_code < 600:
+            raise errors.ClientError(
+                "API error occurred", http_res.status_code, http_res.text, http_res
+            )
+
+
+class PipelineDataSource(PipelineDataClient):
+    def publish(self, request_body: dict) -> operations.PublishEventResponse:
+        """Push a new message into the pipeline
+
+        Args:
+            request_body: The message to be published into the pipeline
+
+        Returns:
+            PublishEventResponse: Response object containing the status code and the raw response
+
+        Raises:
+            ClientError: If an error occurred while publishing the event
+        """
+        request = operations.PublishEventRequest(
+            pipeline_id=self.pipeline_id,
+            x_pipeline_access_token=self.pipeline_access_token,
+            request_body=request_body,
+        )
+
+        url = utils.generate_url(
+            operations.PublishEventRequest,
+            self.glassflow_config.server_url,
+            "/pipelines/{pipeline_id}/topics/input/events",
+            request,
+        )
+
+        req_content_type, data, form = utils.serialize_request_body(
+            request, operations.PublishEventRequest, "request_body", False, True, "json"
+        )
+
+        headers = self._get_headers(request, req_content_type)
+        query_params = utils.get_query_params(operations.PublishEventRequest, request)
+
+        http_res = self.client.request(
+            "POST", url, params=query_params, data=data, files=form, headers=headers
+        )
+        content_type = http_res.headers.get("Content-Type")
+
+        res = operations.PublishEventResponse(
+            status_code=http_res.status_code,
+            content_type=content_type,
+            raw_response=http_res,
+        )
+
+        if http_res.status_code == 200:
+            pass
+        elif http_res.status_code in [400, 500]:
+            if utils.match_content_type(content_type, "application/json"):
+                out = utils.unmarshal_json(http_res.text, errors.Error)
+                out.raw_response = http_res
+                raise out
+            else:
+                raise errors.ClientError(
+                    f"unknown content-type received: {content_type}",
+                    http_res.status_code,
+                    http_res.text,
+                    http_res,
+                )
+        elif 400 < http_res.status_code < 600:
+            raise errors.ClientError(
+                "API error occurred", http_res.status_code, http_res.text, http_res
+            )
+
+        return res
+
+
+class PipelineDataSink(PipelineDataClient):
+    def __init__(self, pipeline_id: str, pipeline_access_token: str):
+        super().__init__(pipeline_id, pipeline_access_token)
+
+        # retry delay for consuming messages (in seconds)
+        self._consume_retry_delay_minimum = 1
+        self._consume_retry_delay_current = 1
+        self._consume_retry_delay_max = 60
+
+    def consume(self) -> operations.ConsumeEventResponse:
+        """Consume the last message from the pipeline
+
+        Returns:
+            ConsumeEventResponse: Response object containing the status code and the raw response
+
+        Raises:
+            ClientError: If an error occurred while consuming the event
+
+        """
+        request = operations.ConsumeEventRequest(
+            pipeline_id=self.pipeline_id,
+            x_pipeline_access_token=self.pipeline_access_token,
+        )
+
+        url = utils.generate_url(
+            operations.ConsumeEventRequest,
+            self.glassflow_config.server_url,
+            "/pipelines/{pipeline_id}/topics/output/events/consume",
+            request,
+        )
+        headers = self._get_headers(request)
+        query_params = utils.get_query_params(operations.ConsumeEventRequest, request)
+
+        # make the request
+        self._respect_retry_delay()
+
+        http_res = self.client.request("POST", url, params=query_params, headers=headers)
+        content_type = http_res.headers.get("Content-Type")
+
+        res = operations.ConsumeEventResponse(
+            status_code=http_res.status_code,
+            content_type=content_type,
+            raw_response=http_res,
+        )
+
+        self._update_retry_delay(http_res.status_code)
+        if http_res.status_code == 200:
+            self._consume_retry_delay_current = self._consume_retry_delay_minimum
+            if utils.match_content_type(content_type, "application/json"):
+                body = utils.unmarshal_json(
+                    http_res.text, Optional[operations.ConsumeEventResponseBody]
+                )
+                res.body = body
+            else:
+                raise errors.ClientError(
+                    f"unknown content-type received: {content_type}",
+                    http_res.status_code,
+                    http_res.text,
+                    http_res,
+                )
+        elif http_res.status_code == 204:
+            # No messages to be consumed.
+            # update the retry delay
+            # Return an empty response body
+            body = operations.ConsumeEventResponseBody("", "", {})
+            res.body = body
+        elif http_res.status_code == 429:
+            # update the retry delay
+            body = operations.ConsumeEventResponseBody("", "", {})
+            res.body = body
+        elif http_res.status_code in [400, 500]:
+            if utils.match_content_type(content_type, "application/json"):
+                out = utils.unmarshal_json(http_res.text, errors.Error)
+                out.raw_response = http_res
+                raise out
+            else:
+                raise errors.ClientError(
+                    f"unknown content-type received: {content_type}",
+                    http_res.status_code,
+                    http_res.text,
+                    http_res,
+                )
+        elif 400 < http_res.status_code < 600:
+            raise errors.ClientError(
+                "API error occurred", http_res.status_code, http_res.text, http_res
+            )
+
+        return res
+
+    def consume_failed(self) -> operations.ConsumeFailedResponse:
+        """Consume the failed message from the pipeline
+
+        Returns:
+            ConsumeFailedResponse: Response object containing the status code and the raw response
+
+        Raises:
+            ClientError: If an error occurred while consuming the event
+
+        """
+        request = operations.ConsumeFailedRequest(
+            pipeline_id=self.pipeline_id,
+            x_pipeline_access_token=self.pipeline_access_token,
+        )
+
+        url = utils.generate_url(
+            operations.ConsumeFailedRequest,
+            self.glassflow_config.server_url,
+            "/pipelines/{pipeline_id}/topics/failed/events/consume",
+            request,
+        )
+        headers = self._get_headers(request)
+        query_params = utils.get_query_params(operations.ConsumeFailedRequest, request)
+
+        self._respect_retry_delay()
+        http_res = self.client.request("POST", url, params=query_params, headers=headers)
+        content_type = http_res.headers.get("Content-Type")
+
+        res = operations.ConsumeFailedResponse(
+            status_code=http_res.status_code,
+            content_type=content_type,
+            raw_response=http_res,
+        )
+
+        self._update_retry_delay(http_res.status_code)
+        if http_res.status_code == 200:
+            if utils.match_content_type(content_type, "application/json"):
+                body = utils.unmarshal_json(
+                    http_res.text, Optional[operations.ConsumeFailedResponseBody]
+                )
+                res.body = body
+            else:
+                raise errors.ClientError(
+                    f"unknown content-type received: {content_type}",
+                    http_res.status_code,
+                    http_res.text,
+                    http_res,
+                )
+        elif http_res.status_code == 204:
+            # No messages to be consumed. Return an empty response body
+            body = operations.ConsumeFailedResponseBody("", "", {})
+            res.body = body
+        elif http_res.status_code in [400, 500]:
+            if utils.match_content_type(content_type, "application/json"):
+                out = utils.unmarshal_json(http_res.text, errors.Error)
+                out.raw_response = http_res
+                raise out
+            else:
+                raise errors.ClientError(
+                    f"unknown content-type received: {content_type}",
+                    http_res.status_code,
+                    http_res.text,
+                    http_res,
+                )
+        elif 400 < http_res.status_code < 600:
+            raise errors.ClientError(
+                "API error occurred", http_res.status_code, http_res.text, http_res
+            )
+
+        return res
+
+    def _update_retry_delay(self, status_code: int):
+        if status_code == 200:
+            self._consume_retry_delay_current = self._consume_retry_delay_minimum
+        elif status_code == 204 or status_code == 429:
+            self._consume_retry_delay_current *= 2
+            self._consume_retry_delay_current = min(
+                self._consume_retry_delay_current, self._consume_retry_delay_max
+            )
+            self._consume_retry_delay_current += random.uniform(0, 0.1)
+
+    def _respect_retry_delay(self):
+        if self._consume_retry_delay_current > self._consume_retry_delay_minimum:
+            # sleep before making the request
+            time.sleep(self._consume_retry_delay_current)


### PR DESCRIPTION
- Add client abstraction `APIClient` to contain all contain abstractions used by all classes communicating with the API
  - It will hold abstraction methods to send requests and handle errors
  - The class is in a separated file for now (due to circular dependency), will move it to `client.py` once we remove the `pipeline_client` method.
- Add top level classes `PipelineDataSource` and `PipelineDataSink` with ability to publish or consume from a pipeline
- Add deprecation warnings on `PipelineClient` and the method `pipeline_client` from `GlassFlowClient`
- Add optional argument `personal_access_token` to `GlassFlowClient` (it adds not functionality for now)
- Remove http client from `GlassFlowConfig` and move it to `APIClient`
