### PR TITLE
remove status from get pipeline response

### DIFF
--- a/src/glassflow/etl/pipeline.py
+++ b/src/glassflow/etl/pipeline.py
@@ -68,7 +68,7 @@ class Pipeline(APIClient):
             "GET", f"{self.ENDPOINT}/{self.pipeline_id}", event_name="PipelineGet"
         )
         self.config = models.PipelineConfig.model_validate(response.json())
-        self.status = models.PipelineStatus(response.json()["status"])
+        self.health()
         self._dlq = DLQ(pipeline_id=self.pipeline_id, host=self.host)
         return self
 

--- a/tests/data/pipeline_configs.py
+++ b/tests/data/pipeline_configs.py
@@ -272,3 +272,13 @@ def get_invalid_config() -> dict:
             "table_mapping": [],  # Empty table mapping should trigger validation error
         },
     }
+
+def get_health_payload(pipeline_id: str) -> dict:
+    """Get a health payload for a pipeline."""
+    return {
+        "pipeline_id": pipeline_id,
+        "pipeline_name": "Test Pipeline",
+        "overall_status": "Running",
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2025-01-01T00:00:00Z",
+    }


### PR DESCRIPTION
- Remove fetching status from GET pipeline response
- Fetch status from /health endpoint instead
- Unify mocking strategy 